### PR TITLE
:bug: Fixes imports to use relative paths rather than absolute paths

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,8 +35,7 @@
     "mocha": "^6.2.2"
   },
   "dependencies": {
-    "double-ended-queue": "^2.1.0-0",
-    "wavy": "^1.0.4"
+    "double-ended-queue": "^2.1.0-0"
   },
   "engine": {
     "node": ">=8.10.0"

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,5 @@
-const { RadixTree } = require("~/src/radix-tree.js");
-const { SEARCH_TYPES } = require("~/src/constants.js")
+const { RadixTree } = require("./radix-tree");
+const { SEARCH_TYPES } = require("./constants")
 
 module.exports = {
   RadixTree,

--- a/src/radix-node.js
+++ b/src/radix-node.js
@@ -1,6 +1,6 @@
-const { SEARCH_TYPES } = require("~/src/constants.js");
-const { defaultPruner } = require("~/src/utils.js");
-const { RadixNodeEdges } = require("~/src/radix-node-edges.js");
+const { SEARCH_TYPES } = require("./constants");
+const { defaultPruner } = require("./utils");
+const { RadixNodeEdges } = require("./radix-node-edges");
 const Deque = require("double-ended-queue");
 
 class RadixNode {

--- a/src/radix-tree.js
+++ b/src/radix-tree.js
@@ -1,6 +1,6 @@
-const { RadixNode } = require("~/src/radix-node.js");
-const { defaultPruner, longestSharedPrefix } = require("~/src/utils.js");
-const { SEARCH_TYPES } = require("~/src/constants.js");
+const { RadixNode } = require("./radix-node");
+const { defaultPruner, longestSharedPrefix } = require("./utils");
+const { SEARCH_TYPES } = require("./constants");
 
 /**
  * The RadixTree class

--- a/test/radix-node-edges.js
+++ b/test/radix-node-edges.js
@@ -1,5 +1,5 @@
 const assert = require("assert");
-const { RadixNodeEdges } = require("~/src/radix-node-edges.js");
+const { RadixNodeEdges } = require("../src/radix-node-edges");
 
 describe("RadixNodeEdges", () => {
   describe(".set(k,v) .get(k)", () => {

--- a/test/radix-node.js
+++ b/test/radix-node.js
@@ -1,8 +1,8 @@
 const assert = require("assert");
 
-const { defaultPruner } = require("~/src/utils.js");
-const { RadixNode } = require("~/src/radix-node.js");
-const { SEARCH_TYPES } = require("~/src/constants.js");
+const { defaultPruner } = require("../src/utils");
+const { RadixNode } = require("../src/radix-node");
+const { SEARCH_TYPES } = require("../src/constants");
 
 describe("RadixNode", () => {
   describe(".addPrefixToChild(prefix, child)", () => {

--- a/test/radix-tree.js
+++ b/test/radix-tree.js
@@ -1,8 +1,8 @@
 const assert = require("assert");
 
-const { RadixTree } = require("~/src/radix-tree.js");
-const { defaultPruner } = require("~/src/utils.js");
-const { SEARCH_TYPES } = require("~/src/constants.js");
+const { RadixTree } = require("../src/radix-tree");
+const { defaultPruner } = require("../src/utils");
+const { SEARCH_TYPES } = require("../src/constants");
 
 describe("RadixTree", () => {
   describe(".set(k, v) and .get(k)", () => {

--- a/test/utils.js
+++ b/test/utils.js
@@ -4,7 +4,7 @@ const {
   decreasingPrefixesOf,
   longestSharedPrefix,
   findKeyHavingSharedPrefix,
-} = require("~/src/utils");
+} = require("../src/utils");
 
 describe("utils", () => {
   describe("#increasingPrefixesOf(s)", () => {


### PR DESCRIPTION
When importing xradix as a library a number of errors are encountered due to the absolute paths specified in imports, this PR changes those paths to relative imports instead - fixing the issue. All tests are passing.